### PR TITLE
Update 32-Operators in Python.md

### DIFF
--- a/variables-data-types-and-operators-in-python/32-Operators in Python.md
+++ b/variables-data-types-and-operators-in-python/32-Operators in Python.md
@@ -35,7 +35,7 @@ x \* y  # multiplication
 
 
 
-### Aritmetic Operators: Meanings & Examples
+### Arithmetic Operators: Meanings & Examples
 
 
 


### PR DESCRIPTION
Added missing 'h' in "Aritmetic Operators: Meanings & Examples"